### PR TITLE
Fix Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
   schedule:
     interval: daily
     time: "13:00"
-  groups:
-    python-packages:
-      patterns:
-        - "*"


### PR DESCRIPTION
Dependabot can't recognize requirements.txt. This might be a fix.
Updates #60